### PR TITLE
Expand site copy and layout

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Contact</title>
+  <title>Contact — Vanja Knežević</title>
 </head>
 <body>
 
@@ -14,10 +14,13 @@
   <a href="contact.html" class="active">Contact</a>
 </nav>
 
-<div class="main_text">
+<div class="container narrow">
+  <h1>Contact</h1>
+  <p>for professional inquiries, collaborations, or speaking invitations, please get in touch via the listed channels. i respond as time permits and prioritize work that aligns with the focus areas described on this site.</p>
   <p><address style="font-style: normal;">email: <a href="mailto:knezevanja@gmail.com">knezevanja@gmail.com</a></address></p>
   <p><address style="font-style: normal;">discord: Kirabo#1728</address></p>
 </div>
 
 </body>
 </html>
+

--- a/essays.html
+++ b/essays.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Essays</title>
+  <title>Essays — Vanja Knežević</title>
 </head>
 <body>
 
@@ -14,25 +14,31 @@
   <a href="contact.html">Contact</a>
 </nav>
 
-<div class="title">Essays</div>
-<div class="main_text" id="essays_list">
-  <a href="essays/vodesign.html">The value of design</a><br>
-</div>
+<div class="container narrow">
+  <h1>Essays</h1>
+  <p>these writings reflect ongoing research into civilizational progress, the intersection of technology and society, and the role of games, art, and design in shaping human futures. they connect practical experience in ai, vr, and game development with broader philosophical inquiry. most pieces are short notes; some expand into longer essays.</p>
 
-<div class="title" id="papers">Papers</div>
-<div class="main_text">
-  <a href="https://drive.google.com/file/d/1qhzRPVFgfeKpEpIHD2dzxfByHYH1yE69/view?usp=sharing">The limits of reusability of material resources on Earth and in similar closed-box systems (2019)</a><br>
-  <a href="https://drive.google.com/file/d/1S9KFKNono-OoiDhF-WuMQyWd5GfYTi9e/view?usp=sharing">Real-Time Analysis of Sunflower Pollination Levels (2017)</a><br>
-</div>
+  <section>
+    <h2>Selected themes</h2>
+    <ul>
+      <li><strong>meta-technology:</strong> institutions, tools, and practices that compound human capability over time.</li>
+      <li><strong>world-building:</strong> how coherent fictional worlds can teach real constraints and trade-offs.</li>
+      <li><strong>simulation &amp; training:</strong> using game engines for learning under uncertainty.</li>
+      <li><strong>design at human scale:</strong> aesthetics, ergonomics, and the craft of making.</li>
+      <li><strong>strategy &amp; governance:</strong> incentives, coordination, and long-horizon decision-making.</li>
+    </ul>
+  </section>
 
-<div class="title">Student work</div>
-<div class="main_text">
-  (All of these are in Serbian only)<br>
-  <a href="https://drive.google.com/file/d/1nkKWF6brNy9y4NKr9ZE508AmQG6upYa_/view?usp=sharing">NFT - tokenizacija ljudi (2020)</a><br>
-  <a href="https://drive.google.com/file/d/1g44Gv4XAlL2ENz-UHoMeDF02PnRaBLUS/view?usp=sharing">Startup analysis - Tesla (2020)</a><br>
-  <a href="https://drive.google.com/file/d/1tnAHuMqeaF8eLsZ2lKrOH4Y_5njusimL/view?usp=sharing">Analiza Apple marketinga (2020)</a><br>
-  <a href="https://drive.google.com/file/d/1UbxOAbruA8Scf61tFVgIlfdD8_kTckbL/view?usp=sharing">Sistemska analiza veze izmedju kreativnosti i tehnologije (2020)</a><br>
+  <section>
+    <h2>Recent notes</h2>
+    <ul>
+      <li><a href="essays/vodesign.html">vodesign — notes on voice, ontology, and interface in design</a></li>
+      <li><a href="essays/empty.html">empty — placeholder</a></li>
+    </ul>
+    <p>for updates and longer drafts, check back occasionally; i prefer publishing when ideas are durable.</p>
+  </section>
 </div>
 
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Vanja Knezevic</title>
+  <title>Vanja Knežević</title>
 </head>
 <body>
 
@@ -14,23 +14,31 @@
   <a href="contact.html">Contact</a>
 </nav>
 
-<div class="title">About me</div>
-<div class="main_text">
-  <p>Civilization doesn't advance on its own. I'm trying to deeply understand what causes civilizational progress, as well as research and build meta-technologies that would help with maintaining and accelerating our advancement.</p>
-  <p>On a less grand scheme, I'm in love with Humanity and the things we make, do and consume, so to stay sane and maintain a sense of normalcy in everyday life, I play with art, music, sports, dances and engineering.</p>
-  <p><a href="essays.html">Here's</a> an overview of the things I think about.</p>
-  <p>And <a href="work.html">here's</a> a rundown of the things I've done and am doing.</p>
-</div>
+<div class="container narrow">
+  <h1>Vanja Knežević</h1>
 
-<div class="title">Current status</div>
-<div class="main_text">
-  <ul>
-    <li>Building <em>Nazralath: The Fallen World</em>, an immersive game nearing release.</li>
-    <li>Developing AI and VR projects at the International Committee of the Red Cross, expanding the team and speaking at international conferences in Belgrade.</li>
-    <li>Board member of the SGA (2023–2025), delivering workshops and talks and co-writing the 2024–2030 strategy for the regional gaming ecosystem.</li>
-  </ul>
+  <section>
+    <h2>About me</h2>
+    <p>civilization does not advance automatically. my work focuses on understanding the forces that drive civilizational progress, and on researching and building meta-technologies that sustain and accelerate it. alongside this broad mission, i remain committed to the human scale: art, design, music, sport, and engineering as essential forms of human expression. these practices ground my everyday life and inform my professional work.</p>
+    <p>i divide my time between two complementary tracks:</p>
+    <ul>
+      <li><strong>euclidean studios</strong> — independent game development, where i co-lead <em>nazralath: the fallen world</em>.</li>
+      <li><strong>international committee of the red cross (icrc)</strong> — virtual reality simulation work, building training experiences for high-stakes humanitarian contexts.</li>
+    </ul>
+    <p>i also serve on the <strong>board of the serbian games association (sga)</strong> and participate in lectures, workshops, and strategy work for the regional games ecosystem.</p>
+    <p>links: see <a href="essays.html"><strong>essays</strong></a> for selected writing and notes. see <a href="work.html"><strong>work</strong></a> for detailed project histories and appearances. for inquiries, visit <a href="contact.html"><strong>contact</strong></a>.</p>
+  </section>
+
+  <section>
+    <h2>Current status</h2>
+    <ul>
+      <li><em>nazralath: the fallen world</em> — narrative-driven dark fantasy game in active development at euclidean studios (creative direction, design, production, cinematic supervision).</li>
+      <li><strong>icrc virtual reality unit</strong> — development of interactive vr training scenarios in unreal engine (simulation design, content direction, engineering support).</li>
+      <li><strong>serbian games association</strong> — board member (2023–2025); lectures, workshops, mentorship; contribution to the 2024–2030 industry strategy.</li>
+    </ul>
+  </section>
 </div>
-<div class="meta_text">19 AUG 2025</div>
 
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -8,6 +8,20 @@ body {
   color: #000;
 }
 
+p {
+  line-height: 1.6;
+}
+
+
+.container {
+  margin: 0 auto;
+}
+
+.narrow {
+  max-width: 70ch;
+  margin: 0 auto;
+}
+
 nav {
   margin-bottom: 40px;
 }
@@ -20,6 +34,11 @@ nav a {
 
 nav a.active {
   font-weight: bold;
+}
+
+h2,
+h3 {
+  margin-top: 2rem;
 }
 
 .title {

--- a/work.html
+++ b/work.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Work</title>
+  <title>Work — Vanja Knežević</title>
 </head>
 <body>
 
@@ -14,14 +14,57 @@
   <a href="contact.html">Contact</a>
 </nav>
 
-<div class="title">Work</div>
-<div class="main_text">
-  <ul>
-    <li><strong>Nazralath: The Fallen World</strong> – building an immersive game that is nearing release.</li>
-    <li><strong>International Committee of the Red Cross (ICRC)</strong> – developing AI and VR projects, growing the team and presenting the work at international conferences in Belgrade.</li>
-    <li><strong>SGA Board Member (2023–2025)</strong> – teaching classes, giving talks and shaping the 2024–2030 strategy for the Serbian and regional gaming ecosystem.</li>
-  </ul>
+<div class="container narrow">
+  <h1>Work</h1>
+
+  <section>
+    <h2>Euclidean Studios — Nazralath: The Fallen World</h2>
+    <p><strong>role:</strong> co-founder; creative director; lead designer; producer.</p>
+    <p><strong>focus:</strong> narrative-driven dark fantasy action-adventure with classic rpg sensibilities.</p>
+    <p><strong>responsibilities:</strong> world-building; narrative, quest and dialogue systems; encounter pacing; cinematic direction; art direction in collaboration with the team; production and project management.</p>
+    <p><strong>notes:</strong> announcement trailer released; ongoing development toward a focused vertical slice and full production. studio operations include publishing discussions, budgeting, community development, and milestone planning.</p>
+  </section>
+
+  <section>
+    <h2>International Committee of the Red Cross (ICRC) — Virtual Reality</h2>
+    <p><strong>role:</strong> vr developer and designer.</p>
+    <p><strong>focus:</strong> immersive simulations for humanitarian training built in unreal engine.</p>
+    <p><strong>responsibilities:</strong> scenario design; interaction design; implementation in ue; technical direction for content quality; collaboration with domain experts; evaluation of training outcomes.</p>
+    <p><strong>appearances &amp; outreach:</strong> periodic presentations and knowledge-sharing within regional vr/game dev meetups and unreal-focused events.</p>
+  </section>
+
+  <section>
+    <h2>Industry and Community</h2>
+    <p><strong>serbian games association (sga), board member (2023–2025):</strong> lectures, workshops, mentorship; contribution to industry strategy (2024–2030).</p>
+    <h3>talks, panels, workshops (selection):</h3>
+    <ul>
+      <li>narrative/game design sessions focused on indie production, team structure, and world-building.</li>
+      <li>vr and simulation design talks on serious applications of game technology.</li>
+      <li>moderation and participation in panels on the serbian indie scene and regional ecosystem development.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Background &amp; Capabilities</h2>
+    <ul>
+      <li><strong>design &amp; production:</strong> narrative and systems design; quest/dialogue architecture; cinematic supervision; milestone planning; scope control.</li>
+      <li><strong>engineering:</strong> unreal engine (c++/blueprints); tooling and pipelines suitable for small teams; performance considerations for real-time content.</li>
+      <li><strong>art direction:</strong> tone and visual coherence; concept review; scene composition; trailer and in-engine cinematic planning.</li>
+      <li><strong>data &amp; ai literacy:</strong> analytical approach to decision-making; comfort with data-informed design and research-driven thinking.</li>
+      <li><strong>collaboration:</strong> cross-functional coordination; mentorship; partner and community engagement.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Selected Appearances (representative)</h2>
+    <ul>
+      <li>unreal-focused meetups and conferences (talks on simulation design and indie production).</li>
+      <li>community workshops on game and narrative design.</li>
+      <li>panel moderation and participation related to the serbian indie ecosystem.</li>
+    </ul>
+  </section>
 </div>
 
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Enrich home page with detailed mission, roles, and current engagements.
- Elaborate work, essays, and contact sections with structured headings and lists.
- Improve readability with a narrow container, heading spacing, and consistent line height.

## Testing
- `npx -y htmlhint index.html work.html essays.html contact.html essays/*.html`
- `npx -y stylelint style.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa30f2608324b2df68d70e02d4e0