### PR TITLE
emphasize interdisciplinary team building and outreach

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,11 @@
   <section>
     <h2>About me</h2>
     <p>civilization does not advance automatically. my work focuses on understanding the forces that drive civilizational progress, and on researching and building meta-technologies that sustain and accelerate it. alongside this broad mission, i remain committed to the human scale: art, design, music, sport, and engineering as essential forms of human expression. these practices ground my everyday life and inform my professional work.</p>
+    <p>my specialty lies in assembling interdisciplinary teams of artists, engineers, designers, and other contributors, aligning them into functional groups that communicate across disciplines and produce diverse work.</p>
     <p>i divide my time between two complementary tracks:</p>
     <ul>
       <li><strong>euclidean studios</strong> — indie game development, where i co-lead <em>nazralath: the fallen world</em>.</li>
-      <li><strong>international committee of the red cross (icrc)</strong> — virtual reality simulation work, building training experiences for high-stakes humanitarian contexts.</li>
+        <li><strong>international committee of the red cross (icrc)</strong> — virtual reality simulation work, building training experiences for high-stakes humanitarian contexts, and supporting recruitment through interviews and local community outreach to grow an interdisciplinary team.</li>
     </ul>
     <p>i also served on the <strong>board of the serbian games association (sga)</strong> and participate in lectures, workshops, and strategy work for the regional games ecosystem.</p>
     <p>links: see <a href="essays.html"><strong>essays</strong></a> for selected writing and notes. see <a href="work.html"><strong>work</strong></a> for detailed project histories and appearances. for inquiries, visit <a href="contact.html"><strong>contact</strong></a>.</p>

--- a/work.html
+++ b/work.html
@@ -29,7 +29,7 @@
     <h2>International Committee of the Red Cross (ICRC) — Virtual Reality</h2>
     <p><strong>role:</strong> vr developer and designer.</p>
     <p><strong>focus:</strong> immersive simulations for humanitarian training built in unreal engine.</p>
-    <p><strong>responsibilities:</strong> scenario design; interaction design; implementation in ue; technical direction for content quality; collaboration with domain experts; evaluation of training outcomes.</p>
+    <p><strong>responsibilities:</strong> scenario design; interaction design; implementation in ue; technical direction for content quality; collaboration with domain experts; evaluation of training outcomes; candidate interviews and local community outreach to recruit an interdisciplinary team.</p>
     <p><strong>appearances &amp; outreach:</strong> periodic presentations and knowledge-sharing within regional vr/game dev meetups and unreal-focused events.</p>
   </section>
 
@@ -51,7 +51,7 @@
       <li><strong>engineering:</strong> unreal engine (c++/blueprints); tooling and pipelines suitable for small teams; performance considerations for real-time content.</li>
       <li><strong>art direction:</strong> tone and visual coherence; concept review; scene composition; trailer and in-engine cinematic planning.</li>
       <li><strong>data &amp; ai literacy:</strong> analytical approach to decision-making; comfort with data-informed design and research-driven thinking.</li>
-      <li><strong>collaboration:</strong> cross-functional coordination; mentorship; partner and community engagement.</li>
+      <li><strong>team-building &amp; collaboration:</strong> assembling interdisciplinary teams of artists, engineers, and designers; fostering cross-discipline communication; mentorship; partner and community engagement.</li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Summary
- note specialty in assembling cross-disciplinary teams and expanding the ICRC role to cover recruitment and community outreach.
- add team-building focus within background & capabilities.

## Testing
- `python -m py_compile essayify.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff7201a0832481e2da0018316fea