### PR TITLE
Remove gifts page from navigation

### DIFF
--- a/gifts.html
+++ b/gifts.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
+  <title>Gifts — Vanja Knežević</title>
+</head>
+<body>
+
+<nav>
+  <a href="index.html">Home</a>
+  <a href="essays.html">Essays</a>
+  <a href="work.html">Work</a>
+  <a href="contact.html">Contact</a>
+</nav>
+
+<div class="container narrow">
+  <h1>Gifts</h1>
+  <p>thank you for asking! here are a few ideas that would be meaningful, plus items i already own and enjoy. price ranges are rough and flexible.</p>
+
+  <section>
+    <h2>Wishlist</h2>
+    <div class="gift-grid">
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=600&q=80" alt="Pair of over-ear headphones">
+        <div class="gift-content">
+          <h3>Open-back studio headphones</h3>
+          <p class="gift-reason">For focused writing and mixing without ear fatigue. Prefer neutral tuning and replaceable parts for longevity.</p>
+          <p class="gift-price">Approx. 150–250 €</p>
+        </div>
+      </article>
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1466692476868-aef1dfb1e735?auto=format&fit=crop&w=600&q=80" alt="Stack of art books on a desk">
+        <div class="gift-content">
+          <h3>Art and world-building books</h3>
+          <p class="gift-reason">Reference books on architecture, costume, or myth—useful for game narrative and visual direction.</p>
+          <p class="gift-price">Approx. 30–70 € per book</p>
+        </div>
+      </article>
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1505575967455-40e256f73376?auto=format&fit=crop&w=600&q=80" alt="Leather notebook and fountain pen">
+        <div class="gift-content">
+          <h3>Fountain pen ink + notebooks</h3>
+          <p class="gift-reason">I keep daily handwritten notes; enjoy subtle inks and plain, smooth paper (A5 size, dot or blank).</p>
+          <p class="gift-price">Approx. 15–40 €</p>
+        </div>
+      </article>
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1470246973918-29a93221c455?auto=format&fit=crop&w=600&q=80" alt="Acoustic guitar leaning on a wall">
+        <div class="gift-content">
+          <h3>Guitar maintenance kit</h3>
+          <p class="gift-reason">String care, fretboard oil, and a compact toolkit keep my instruments ready for recording sessions.</p>
+          <p class="gift-price">Approx. 25–60 €</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section>
+    <h2>Already loved</h2>
+    <p>these gifts have been wonderful—use them as inspiration if you want to riff on the themes.</p>
+    <div class="gift-grid">
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1507676184212-d03ab07a01bf?auto=format&fit=crop&w=600&q=80" alt="Laptop stand on a desk">
+        <div class="gift-content">
+          <h3>Aluminum laptop stand</h3>
+          <p class="gift-reason">Raised my screen to eye level and eased long writing sessions. Compact enough for travel.</p>
+          <p class="gift-price">Gifted &amp; appreciated</p>
+        </div>
+      </article>
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=600&q=80" alt="Assorted loose leaf tea">
+        <div class="gift-content">
+          <h3>Loose leaf tea sampler</h3>
+          <p class="gift-reason">Great for mindful breaks during production days. Complex oolongs and herbal blends are favorites.</p>
+          <p class="gift-price">Gifted &amp; enjoyed</p>
+        </div>
+      </article>
+      <article class="gift-card">
+        <img src="https://images.unsplash.com/photo-1527443224154-d756c5e0cddf?auto=format&fit=crop&w=600&q=80" alt="Compact mechanical keyboard">
+        <div class="gift-content">
+          <h3>Compact mechanical keyboard</h3>
+          <p class="gift-reason">Improved ergonomics and typing feel while working between Unreal Engine and writing drafts.</p>
+          <p class="gift-price">Gifted &amp; used daily</p>
+        </div>
+      </article>
+    </div>
+  </section>
+</div>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,52 @@ nav a.active {
   font-weight: bold;
 }
 
+.gift-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin: 20px 0;
+}
+
+.gift-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.gift-card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+
+.gift-content {
+  padding: 12px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gift-content h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.gift-reason {
+  margin: 0;
+  font-size: 15px;
+}
+
+.gift-price {
+  margin: 0;
+  font-size: 14px;
+  color: #555;
+}
+
 h2,
 h3 {
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- remove the Gifts link from the site-wide navigation on all pages
- keep the new gifts page accessible directly via URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb68628348324a9a2d92df984ea94)