### PR TITLE
Add live heart rate widget to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,14 @@
       <li><strong><a href="https://sga.rs/" target="_blank">serbian games association</a></strong> — board member (2023–2025); lectures, workshops, mentorship; contribution to the 2024–2030 industry strategy.</li>
     </ul>
   </section>
+
+  <section>
+    <h2>Live heart rate</h2>
+    <p>btw here's my real-time heart rate. my amygdala is pretty hard to rile up, so don't expect crazy numbers.</p>
+    <div class="widget-embed">
+      <iframe src="https://pulsoid.net/widget/view/9084fc0c-5cff-4367-90ef-75fdd1b9ebf5" title="Real-time heart rate" loading="lazy"></iframe>
+    </div>
+  </section>
 </div>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -116,3 +116,15 @@ a:visited {
 a:hover, a:focus {
   color: #3949ab; /* lighter but still dark */
 }
+
+.widget-embed {
+  margin: 20px 0 10px;
+}
+
+.widget-embed iframe {
+  width: 100%;
+  max-width: 420px;
+  height: 260px;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+}


### PR DESCRIPTION
## Summary
- add a live heart rate section to the homepage with the provided Pulsoid widget
- style the embedded widget for consistent sizing and presentation

## Testing
- not run (static content update)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cbd8f114832484f5ee54f60e2871)