### PR TITLE
Center heart rate widget on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -119,6 +119,8 @@ a:hover, a:focus {
 
 .widget-embed {
   margin: 20px 0 10px;
+  display: flex;
+  justify-content: center;
 }
 
 .widget-embed iframe {
@@ -126,4 +128,5 @@ a:hover, a:focus {
   max-width: 360px;
   height: 180px;
   border: none;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- center the embedded heart rate widget within its container
- ensure the iframe renders as a block element to avoid offset positioning on small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69430374ffac83248884256c265823a5)