### PR TITLE
Improve mobile padding and text wrapping

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,13 +3,17 @@ body {
   max-width: 700px;
   margin: 40px auto;
   padding: 0 10px;
+  padding-left: max(10px, env(safe-area-inset-left));
+  padding-right: max(10px, env(safe-area-inset-right));
   line-height: 1.6;
   background: #fff;
   color: #000;
+  overflow-x: hidden;
 }
 
 p {
   line-height: 1.6;
+  word-break: break-word;
 }
 
 


### PR DESCRIPTION
## Summary
- add safe-area padding to avoid content being cut off on mobile
- hide horizontal overflow and allow long text to wrap cleanly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433c1542c483249c801f6b5b3432b3)