### PR TITLE
Refocus homepage for recruiter-focused hiring sprint

### DIFF
--- a/assets/vanja-knezevic-cv.pdf
+++ b/assets/vanja-knezevic-cv.pdf
@@ -1,0 +1,61 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 578 >>
+stream
+BT
+/F1 12 Tf
+50 780 Td
+14 TL
+(Vanja Knezevic - CV) Tj
+T*
+(Technical Creative Director) Tj
+T*
+() Tj
+T*
+(Focus: Real-time interactive systems, Unreal Engine, XR simulation, AI creative pipelines) Tj
+T*
+() Tj
+T*
+(Experience) Tj
+T*
+(- Co-founder, Euclidean Studios) Tj
+T*
+(- Former VR Designer, International Committee of the Red Cross) Tj
+T*
+(- Board Member, Serbian Games Association) Tj
+T*
+() Tj
+T*
+(Open to: Technical Director, Creative Technology Leadership, Simulation/XR roles) Tj
+T*
+(Contact: vanja@euclideanstudios.com) Tj
+T*
+(LinkedIn: linkedin.com/in/vanjaknezevic) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000870 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+940
+%%EOF

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Vanja Knežević</title>
+  <title>Vanja Knežević — Technical Creative Director | Unreal Engine | XR Simulation</title>
 </head>
 <body>
 
@@ -15,38 +15,83 @@
 </nav>
 
 <div class="container narrow">
-  <h1>Vanja Knežević</h1>
+  <header class="hero">
+    <h1>Vanja Knežević</h1>
+    <p class="hero-role">Technical Creative Director</p>
+    <p><strong>Building real-time interactive systems in Unreal Engine.</strong></p>
+    <p>Experience across: games • VR simulation • AI creative pipelines.</p>
+    <p>Former VR Designer — ICRC<br>Co-founder — Euclidean Studios<br>Board Member — Serbian Games Association</p>
+  </header>
 
   <section>
-    <h2>About me</h2>
-    <p>i am a lead developer and technical director working across game development, real-time 3d, simulation, and interdisciplinary systems design. i co-founded <a href="https://euclideanstudios.com/" target="_blank">euclidean studios</a> and founded <a href="https://arda.euclideanstudios.com/" target="_blank">arda</a>, where i lead technical direction, r&amp;d, and production strategy across games, animation, simulation, and interactive media.</p>
-    <p>my background is rooted in data science, data engineering, computer vision, and artificial intelligence. that analytical, systems-level foundation still drives how i approach unreal engine architecture, simulation design, and production pipelines.</p>
-    <p>my specialty lies in assembling interdisciplinary teams of artists, engineers, and designers, aligning them into production systems that translate complex creative or institutional problems into robust interactive and visual outputs.</p>
-    <p>i divide my time between two complementary tracks:</p>
+    <h2>Hire me / Availability</h2>
+    <p>Currently exploring:</p>
     <ul>
-        <li><strong><a href="https://euclideanstudios.com/" target="_blank">euclidean studios</a></strong> — game development and interactive production, including <a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank"><em>nazralath: the fallen world</em></a>.</li>
-        <li><strong><a href="https://arda.euclideanstudios.com/" target="_blank">arda</a></strong> — multidisciplinary animated media and 3d/interactive production spanning concept development, storyboarding, animation, simulation, and post-production.</li>
+      <li>Technical Director roles</li>
+      <li>Creative technology leadership</li>
+      <li>Simulation / XR systems</li>
+      <li>AI-enabled content pipelines</li>
     </ul>
-    <p>previously, i worked within the <strong><a href="https://www.icrc.org/" target="_blank">icrc</a> virtual reality unit in belgrade</strong>, contributing to immersive simulation and training projects. the unit has since been closed.</p>
-    <p>i continue to contribute through lectures, workshops, and mentorship across the regional games and real-time media ecosystem.</p>
-    <p>links: see <a href="essays.html"><strong>essays</strong></a> for selected writing and notes. see <a href="work.html"><strong>work</strong></a> for detailed project histories and appearances. for inquiries, visit <a href="contact.html"><strong>contact</strong></a>.</p>
+    <p>Open to consulting, contract, or full-time opportunities.</p>
+    <p><a class="button-link" href="assets/vanja-knezevic-cv.pdf" download>Download CV</a></p>
   </section>
 
   <section>
-    <h2>Current status</h2>
+    <h2>Projects</h2>
+    <article>
+      <h3>Nazralath: The Fallen World</h3>
+      <ul>
+        <li><strong>Role:</strong> Director / Technical Design</li>
+        <li><strong>Engine:</strong> Unreal Engine 5</li>
+        <li><strong>Type:</strong> Narrative RPG</li>
+        <li><strong>Focus:</strong> Systemic world design and technical pipeline</li>
+      </ul>
+    </article>
+    <article>
+      <h3>VR Humanitarian Simulation</h3>
+      <ul>
+        <li><strong>Role:</strong> VR Designer</li>
+        <li><strong>Org:</strong> International Committee of the Red Cross</li>
+        <li><strong>Type:</strong> Training simulations</li>
+        <li><strong>Focus:</strong> Immersive decision-making scenarios</li>
+      </ul>
+    </article>
+  </section>
+
+  <section>
+    <h2>Systems thinking</h2>
+    <p>Areas of expertise:</p>
     <ul>
-      <li><a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank"><em>nazralath: the fallen world</em></a> — narrative-driven dark fantasy game in active development at <a href="https://euclideanstudios.com/" target="_blank">euclidean studios</a> (engineering, design, writing, production).</li>
-      <li><strong><a href="https://arda.euclideanstudios.com/" target="_blank">arda</a></strong> — lead developer &amp; technical director; overseeing technical direction, r&amp;d, and production strategy across animated media, simulation, and interactive pipelines.</li>
-      <li><strong>regional contributions</strong> — lectures, workshops, and mentorship across game development, unreal engine production, and simulation design.</li>
+      <li>Real-time simulation systems</li>
+      <li>Game and narrative design architecture</li>
+      <li>AI-assisted creative pipelines</li>
+      <li>Technical art direction</li>
+      <li>Interdisciplinary product leadership</li>
     </ul>
   </section>
 
   <section>
-    <h2>Live heart rate</h2>
-    <p>btw there may or may not be my real-time heart rate below this paragraph. (depends on whether i'm wearing watch, app is running etc.) my amygdala is pretty hard to rile up, so don't expect crazy numbers.</p>
-    <div class="widget-embed">
-      <iframe src="https://pulsoid.net/widget/view/9084fc0c-5cff-4367-90ef-75fdd1b9ebf5" title="Real-time heart rate" loading="lazy"></iframe>
-    </div>
+    <h2>Showreel</h2>
+    <p><strong>Showreel coming soon.</strong><br>(Selected work available upon request.)</p>
+  </section>
+
+  <section>
+    <h2>Talks &amp; Writing</h2>
+    <p>Selected leadership and industry contributions:</p>
+    <ul>
+      <li>Demystifying the games industry</li>
+      <li>Serbian Games Association panels</li>
+      <li>Game design and interdisciplinary teams</li>
+    </ul>
+    <p>Explore <a href="essays.html">essays</a> and additional <a href="work.html">talks and work history</a>.</p>
+  </section>
+
+  <section>
+    <h2>Contact</h2>
+    <p>
+      <a href="mailto:vanja@euclideanstudios.com">vanja@euclideanstudios.com</a><br>
+      <a href="https://linkedin.com/in/vanjaknezevic" target="_blank" rel="noopener noreferrer">linkedin.com/in/vanjaknezevic</a>
+    </p>
   </section>
 </div>
 

--- a/style.css
+++ b/style.css
@@ -140,3 +140,27 @@ a:hover, a:focus {
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
 }
+
+.hero {
+  margin-bottom: 2rem;
+}
+
+.hero-role {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-top: -0.2rem;
+}
+
+.button-link {
+  display: inline-block;
+  padding: 8px 14px;
+  border: 1px solid #1a237e;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.button-link:hover,
+.button-link:focus {
+  background: #eef1ff;
+}


### PR DESCRIPTION
### Motivation
- Convert the existing portfolio into a recruiter-first landing page for a 1-week outreach sprint so visitors can answer “who, what, why” within five seconds. 
- Surface explicit hiring signals and an easy conversion path (direct contact + CV download) to improve recruiter response rates. 
- Emphasize simulation/XR technical leadership and Unreal Engine experience to target higher-probability roles. 

### Description
- Reworked `index.html` to add a hero with name, role, one-line value proposition, credibility items, and an explicit `Hire me / Availability` section with target roles and engagement types. 
- Replaced the previous homepage sections with structured hiring-focused blocks: `Projects` (two project entries), `Systems thinking`, `Showreel` placeholder, `Talks & Writing`, and a direct `Contact` block, and removed the live heart-rate widget. 
- Updated the SEO title tag to `Vanja Knežević — Technical Creative Director | Unreal Engine | XR Simulation` and added a downloadable CV at `assets/vanja-knezevic-cv.pdf` wired to a CTA button. 
- Added minimal styling in `style.css` for the hero presentation and `.button-link` CTA to support the updated layout. 

### Testing
- Served the site locally with `python -m http.server 8000` and confirmed the server started successfully. 
- Captured a full-page screenshot of the updated homepage using Playwright to validate layout and content changes, which completed successfully. 
- Verified the CV asset exists and has a valid PDF header by checking the file bytes with a short Python snippet (`%PDF-1.4`), which succeeded. 
- Attempted to run a `file`-based check (`file assets/vanja-knezevic-cv.pdf`) but the `file` utility is not available in this environment, so that specific check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b339c7af048324b3244976a5e082ee)