### PR TITLE
Add canonical/og:url tags, sitemap & robots, and update contact links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/contact.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/contact.html">
   <link rel="stylesheet" href="style.css">
   <title>Contact — Vanja Knežević</title>
 </head>
@@ -17,7 +19,7 @@
 <div class="container narrow">
   <h1>Contact</h1>
   <p>for professional inquiries, collaborations, or speaking invitations, please get in touch via the listed channels. i respond as time permits and prioritize work that aligns with the focus areas described on this site.</p>
-  <p><address style="font-style: normal;">email: <a href="mailto:knezevanja@gmail.com">knezevanja@gmail.com</a></address></p>
+  <p><address style="font-style: normal;">email: <a href="mailto:hello@vanjaknezevic.com">hello@vanjaknezevic.com</a></address></p>
   <p><address style="font-style: normal;">x: <a href="https://x.com/umetnist" target="_blank">@umetnist</a></address></p>
   <p><address style="font-style: normal;">discord: <a href="https://discord.com/" target="_blank">kirabo</a></address></p>
 </div>

--- a/essays.html
+++ b/essays.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/essays.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/essays.html">
   <link rel="stylesheet" href="style.css">
   <title>Essays — Vanja Knežević</title>
 </head>

--- a/essays/empty.html
+++ b/essays/empty.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/essays/empty.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/essays/empty.html">
   <link rel="stylesheet" href="../style.css">
   <title>ESSAY_TITLE</title>
 </head>

--- a/essays/vodesign.html
+++ b/essays/vodesign.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/essays/vodesign.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/essays/vodesign.html">
   <link rel="stylesheet" href="../style.css">
   <title>The value of design</title>
 </head>

--- a/gifts.html
+++ b/gifts.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/gifts.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/gifts.html">
   <link rel="stylesheet" href="style.css">
   <title>Gifts — Vanja Knežević</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/">
+  <meta property="og:url" content="https://vanjaknezevic.com/">
   <link rel="stylesheet" href="style.css">
   <title>Vanja Knežević — Technical Creative Director | Unreal Engine | XR Simulation</title>
 </head>
@@ -90,8 +92,8 @@
   <section>
     <h2>Contact</h2>
     <p>
-      <a href="mailto:vanja@euclideanstudios.com">vanja@euclideanstudios.com</a><br>
-      <a href="https://linkedin.com/in/vanjaknezevic" target="_blank" rel="noopener noreferrer">linkedin.com/in/vanjaknezevic</a>
+      <a href="mailto:hello@vanjaknezevic.com">hello@vanjaknezevic.com</a><br>
+      <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a>
     </p>
   </section>
 </div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,17 @@
+# Vanja Knežević — site map for LLMs
+
+This website is fully static HTML and can be read without JavaScript.
+
+Primary pages:
+- https://vanjaknezevic.com/
+- https://vanjaknezevic.com/work.html
+- https://vanjaknezevic.com/essays.html
+- https://vanjaknezevic.com/contact.html
+
+Essay pages:
+- https://vanjaknezevic.com/essays/vodesign.html
+- https://vanjaknezevic.com/essays/empty.html
+
+Contact:
+- Email: hello@vanjaknezevic.com
+- LinkedIn: https://www.linkedin.com/in/knezevic-vanja/

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vanjaknezevic.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://vanjaknezevic.com/</loc></url>
+  <url><loc>https://vanjaknezevic.com/index.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/work.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/essays.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/contact.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/gifts.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/essays/vodesign.html</loc></url>
+  <url><loc>https://vanjaknezevic.com/essays/empty.html</loc></url>
+</urlset>

--- a/work.html
+++ b/work.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://vanjaknezevic.com/work.html">
+  <meta property="og:url" content="https://vanjaknezevic.com/work.html">
   <link rel="stylesheet" href="style.css">
   <title>Work — Vanja Knežević</title>
 </head>


### PR DESCRIPTION
### Motivation

- Improve SEO and social sharing by declaring canonical URLs and Open Graph page URLs for key pages. 
- Standardize public contact details and social links to the primary email and LinkedIn profile. 
- Help crawlers and external tools (including LLMs) discover site structure by adding a sitemap, robots directives, and a small site map file. 

### Description

- Added `<link rel="canonical">` and `<meta property="og:url">` tags to `index.html`, `work.html`, `essays.html`, `gifts.html`, `contact.html`, and `essays/*` pages. 
- Updated contact email to `hello@vanjaknezevic.com` in `contact.html` and `index.html`, and replaced the LinkedIn link with the `linkedin.com/in/knezevic-vanja` URL. 
- Added `sitemap.xml`, `robots.txt`, and `llms.txt` with a list of primary pages and crawl/sitemap directives. 
- Preserved existing content and layout in pages while updating meta and contact details. 

### Testing

- No automated tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b403999d34832487f026a4af2af29f)