### PR TITLE
Force HTTPS and upgrade insecure requests across all HTML pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/contact.html">
   <meta property="og:url" content="https://vanjaknezevic.com/contact.html">
   <link rel="stylesheet" href="style.css">

--- a/essays.html
+++ b/essays.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/essays.html">
   <meta property="og:url" content="https://vanjaknezevic.com/essays.html">
   <link rel="stylesheet" href="style.css">

--- a/essays/empty.html
+++ b/essays/empty.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/essays/empty.html">
   <meta property="og:url" content="https://vanjaknezevic.com/essays/empty.html">
   <link rel="stylesheet" href="../style.css">

--- a/essays/vodesign.html
+++ b/essays/vodesign.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/essays/vodesign.html">
   <meta property="og:url" content="https://vanjaknezevic.com/essays/vodesign.html">
   <link rel="stylesheet" href="../style.css">

--- a/gifts.html
+++ b/gifts.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/gifts.html">
   <meta property="og:url" content="https://vanjaknezevic.com/gifts.html">
   <link rel="stylesheet" href="style.css">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/">
   <meta property="og:url" content="https://vanjaknezevic.com/">
   <link rel="stylesheet" href="style.css">

--- a/work.html
+++ b/work.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <script>if (location.protocol === "http:") location.replace("https://" + location.host + location.pathname + location.search + location.hash);</script>
   <link rel="canonical" href="https://vanjaknezevic.com/work.html">
   <meta property="og:url" content="https://vanjaknezevic.com/work.html">
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
### Motivation
- Browsers can block mixed active content when secure pages attempt to load insecure `http://` resources, which can cause pages to render blank; the site needs a simple, client-side hardening to ensure pages upgrade or redirect to HTTPS.

### Description
- Added a page-level `Content-Security-Policy` meta tag with `upgrade-insecure-requests` to each primary HTML entry page.
- Added an early `<script>` in the `<head>` that redirects `http://` requests to the equivalent `https://` URL to handle clients that reach the site via HTTP.
- Applied these changes to `index.html`, `work.html`, `essays.html`, `contact.html`, `gifts.html`, `essays/empty.html`, and `essays/vodesign.html`.

### Testing
- Ran `rg -n "upgrade-insecure-requests|location.protocol === \"http:\""` against the updated files to confirm both the CSP meta tag and redirect script are present, and the search returned matches for all seven files (success).
- Inspected the file heads with `nl -ba <file>` for each updated file to verify the meta tag and script appear early in the `<head>` (success).
- Verified the working tree showed the intended files as modified after the changes (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d5f758cc8324a5874470455911f4)