### PR TITLE
Embed Vimeo showreel and polish site copy for leadership positioning

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Contact — Vanja Knežević</title>
+  <title>Contact - Vanja Knežević</title>
 </head>
 <body>
 
@@ -16,10 +16,10 @@
 
 <div class="container narrow">
   <h1>Contact</h1>
-  <p>for professional inquiries, collaborations, or speaking invitations, please get in touch via the listed channels. i respond as time permits and prioritize work that aligns with the focus areas described on this site.</p>
-  <p><address style="font-style: normal;">email: <a href="mailto:knezevanja@gmail.com">knezevanja@gmail.com</a></address></p>
-  <p><address style="font-style: normal;">x: <a href="https://x.com/umetnist" target="_blank">@umetnist</a></address></p>
-  <p><address style="font-style: normal;">discord: <a href="https://discord.com/" target="_blank">kirabo</a></address></p>
+  <p>For professional inquiries, collaborations, or speaking invitations, please get in touch via the listed channels. I respond as time permits and prioritize work aligned with leadership, strategy, and interactive product delivery.</p>
+  <p><address style="font-style: normal;">Email: <a href="mailto:knezevanja@gmail.com">knezevanja@gmail.com</a></address></p>
+  <p><address style="font-style: normal;">X: <a href="https://x.com/umetnist" target="_blank">@umetnist</a></address></p>
+  <p><address style="font-style: normal;">Discord: <a href="https://discord.com/" target="_blank">kirabo</a></address></p>
 </div>
 
 </body>

--- a/essays.html
+++ b/essays.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Essays — Vanja Knežević</title>
+  <title>Essays - Vanja Knežević</title>
 </head>
 <body>
 
@@ -16,26 +16,26 @@
 
 <div class="container narrow">
   <h1>Essays</h1>
-  <p>these writings reflect ongoing research into civilizational progress, the intersection of technology and society, and the role of games, art, and design in shaping human futures. they connect practical experience in ai, vr, and game development with broader philosophical inquiry. most pieces are short notes; some expand into longer essays.</p>
+  <p>These writings reflect ongoing research into civilizational progress, the intersection of technology and society, and the role of games, art, and design in shaping human futures. They connect practical experience in AI, VR, and game development with broader philosophical inquiry. Most pieces are short notes; some expand into longer essays.</p>
 
   <section>
     <h2>Selected themes</h2>
     <ul>
-      <li><strong>meta-technology:</strong> institutions, tools, and practices that compound human capability over time.</li>
-      <li><strong>world-building:</strong> how coherent fictional worlds can teach real constraints and trade-offs.</li>
-      <li><strong>simulation &amp; training:</strong> using game engines for learning under uncertainty.</li>
-      <li><strong>design at human scale:</strong> aesthetics, ergonomics, and the craft of making.</li>
-      <li><strong>strategy &amp; governance:</strong> incentives, coordination, and long-horizon decision-making.</li>
+      <li><strong>Meta-Technology:</strong> Institutions, tools, and practices that compound human capability over time.</li>
+      <li><strong>World-Building:</strong> How coherent fictional worlds can teach real constraints and trade-offs.</li>
+      <li><strong>Simulation &amp; Training:</strong> Using game engines for learning under uncertainty.</li>
+      <li><strong>Design at Human Scale:</strong> Aesthetics, ergonomics, and the craft of making.</li>
+      <li><strong>Strategy &amp; Governance:</strong> Incentives, coordination, and long-horizon decision-making.</li>
     </ul>
   </section>
 
   <section>
     <h2>Recent notes</h2>
     <ul>
-      <li><a href="essays/vodesign.html">vodesign — notes on voice, ontology, and interface in design</a></li>
-      <li><a href="essays/empty.html">empty — placeholder</a></li>
+      <li><a href="essays/vodesign.html">Vodesign - Notes on Voice, Ontology, and Interface in Design</a></li>
+      <li><a href="essays/empty.html">Empty - Placeholder</a></li>
     </ul>
-    <p>for updates and longer drafts, check back occasionally; i prefer publishing when ideas are durable.</p>
+    <p>For updates and longer drafts, check back occasionally; I prefer publishing when ideas are durable.</p>
   </section>
 </div>
 

--- a/gifts.html
+++ b/gifts.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Gifts — Vanja Knežević</title>
+  <title>Gifts - Vanja Knežević</title>
 </head>
 <body>
 
@@ -16,7 +16,7 @@
 
 <div class="container narrow">
   <h1>Gifts</h1>
-  <p>thank you for asking! here are a few ideas that would be meaningful, plus items i already own and enjoy. price ranges are rough and flexible.</p>
+  <p>Thank you for asking! Here are a few ideas that would be meaningful, plus items I already own and enjoy. Price ranges are rough and flexible.</p>
 
   <section>
     <h2>Wishlist</h2>
@@ -33,7 +33,7 @@
         <img src="https://images.unsplash.com/photo-1466692476868-aef1dfb1e735?auto=format&fit=crop&w=600&q=80" alt="Stack of art books on a desk">
         <div class="gift-content">
           <h3>Art and world-building books</h3>
-          <p class="gift-reason">Reference books on architecture, costume, or myth—useful for game narrative and visual direction.</p>
+          <p class="gift-reason">Reference books on architecture, costume, or myth - useful for game narrative and visual direction.</p>
           <p class="gift-price">Approx. 30–70 € per book</p>
         </div>
       </article>
@@ -58,7 +58,7 @@
 
   <section>
     <h2>Already loved</h2>
-    <p>these gifts have been wonderful—use them as inspiration if you want to riff on the themes.</p>
+    <p>These gifts have been wonderful - use them as inspiration if you want to riff on the themes.</p>
     <div class="gift-grid">
       <article class="gift-card">
         <img src="https://images.unsplash.com/photo-1507676184212-d03ab07a01bf?auto=format&fit=crop&w=600&q=80" alt="Laptop stand on a desk">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Vanja Knežević — Technical Creative Director | Unreal Engine | XR Simulation</title>
+  <title>Vanja Knežević - Technical Creative Director | Unreal Engine | XR Simulation</title>
 </head>
 <body>
 
@@ -17,10 +17,10 @@
 <div class="container narrow">
   <header class="hero">
     <h1>Vanja Knežević</h1>
-    <p class="hero-role">Creative Technologist & Technical Director for real-time interactive systems</p>
-    <p><strong>Leading the design and delivery of interactive systems across simulation, experience design, and AI-enabled products.</strong></p>
-    <p>Experience spanning games, VR simulation, AI-native workflows, and interdisciplinary leadership</p>
-    <p>Former VR Designer & R&D Lead at ICRC<br>Co-founder & Director at Euclidean Studios<br>Former Board Member at the Serbian Games Association</p>
+    <p class="hero-role">Creative Technologist, Technical Director, and Team Lead for Real-Time Interactive Systems</p>
+    <p><strong>I lead strategy, team formation, and end-to-end delivery for simulation, experience design, and AI-enabled interactive products.</strong></p>
+    <p>Experience spanning games, VR simulation, AI-native workflows, cross-functional leadership, and organizational development.</p>
+    <p>Former VR Designer & R&D Lead at ICRC<br>Co-Founder & Director at Euclidean Studios<br>Former Board Member at the Serbian Games Association</p>
   </header>
 
   <section>
@@ -60,7 +60,7 @@
   </section>
 
   <section>
-    <h2>Systems thinking</h2>
+    <h2>Systems Thinking</h2>
     <p>Core areas:</p>
     <ul>
       <li>Interdisciplinary systems leadership</li>
@@ -73,7 +73,15 @@
 
   <section>
     <h2>Showreel</h2>
-    <p><strong>Showreel in preparation.</strong><br>Selected work and technical breakdowns are available on request.</p>
+    <p>Selected leadership and delivery work across game development, simulation, and interactive production:</p>
+    <div class="video-embed">
+      <iframe
+        src="https://player.vimeo.com/video/1177113461"
+        title="Vanja Knežević Showreel"
+        allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
+        allowfullscreen>
+      </iframe>
+    </div>
   </section>
 
   <section>
@@ -84,7 +92,7 @@
       <li>Panels, lectures, and workshops through the Serbian Games Association</li>
       <li>Leading and scaling interdisciplinary teams</li>
     </ul>
-    <p>Explore <a href="essays.html">essays</a> and additional <a href="work.html">talks and work history</a>.</p>
+    <p>Explore <a href="essays.html">Essays</a> and additional <a href="work.html">Talks and Work History</a>.</p>
   </section>
 
   <section>

--- a/style.css
+++ b/style.css
@@ -164,3 +164,19 @@ a:hover, a:focus {
 .button-link:focus {
   background: #eef1ff;
 }
+
+
+.video-embed {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  margin: 12px 0 8px;
+}
+
+.video-embed iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/work.html
+++ b/work.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Work — Vanja Knežević</title>
+  <title>Work - Vanja Knežević</title>
 </head>
 <body>
 
@@ -18,48 +18,48 @@
   <h1>Work</h1>
 
   <section>
-    <h2><a href="https://euclideanstudios.com/" target="_blank">Euclidean Studios</a> — <a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank">Nazralath: The Fallen World</a></h2>
-    <p><strong>role:</strong> co-founder; tech director; producer.</p>
-    <p><strong>focus:</strong> a systems-driven dark fantasy RPG with strong narrative structure and world-state reactivity.</p>
-    <p><strong>responsibilities:</strong> technical direction; systems architecture for narrative, quest, and dialogue; encounter design cadence; engineering leadership; production ownership.</p>
-    <p><strong>notes:</strong> announcement trailer released; currently directing vertical-slice execution and production planning, including publishing strategy, budgeting, and milestone governance.</p>
+    <h2><a href="https://euclideanstudios.com/" target="_blank">Euclidean Studios</a> - <a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank">Nazralath: The Fallen World</a></h2>
+    <p><strong>Role:</strong> Co-Founder; Technical Director; Producer.</p>
+    <p><strong>Focus:</strong> A systems-driven dark fantasy RPG with strong narrative structure and world-state reactivity.</p>
+    <p><strong>Responsibilities:</strong> Technical direction; systems architecture for narrative, quest, and dialogue; cross-discipline leadership; hiring and team development; roadmap ownership; production governance.</p>
+    <p><strong>Notes:</strong> Announcement trailer released; currently directing vertical-slice execution and production planning, including publishing strategy, budgeting, and milestone governance.</p>
   </section>
 
   <section>
-    <h2><a href="https://arda.euclideanstudios.com/" target="_blank">ARDA</a> — Animated Media &amp; Interactive Production</h2>
-    <p><strong>role:</strong> founder; lead developer &amp; technical director.</p>
-    <p><strong>focus:</strong> R&D-led interactive production spanning concept, previs, animation, simulation, and final delivery.</p>
-    <p><strong>responsibilities:</strong> technical direction; R&amp;D leadership; production strategy; Unreal Engine architecture; cross-discipline systems design; pipeline design for art, engineering, and narrative teams.</p>
-    <p><strong>notes:</strong> ARDA operates as a core capability within Euclidean Studios for high-fidelity 3D content, interactive experiences, and complex technical delivery pipelines.</p>
+    <h2><a href="https://arda.euclideanstudios.com/" target="_blank">ARDA</a> - Animated Media &amp; Interactive Production</h2>
+    <p><strong>Role:</strong> Founder; Lead Developer &amp; Technical Director.</p>
+    <p><strong>Focus:</strong> R&D-led interactive production spanning concept, previs, animation, simulation, and final delivery.</p>
+    <p><strong>Responsibilities:</strong> Technical direction; R&amp;D leadership; production strategy; Unreal Engine architecture; cross-discipline systems design; and pipeline design that aligns art, engineering, and narrative teams.</p>
+    <p><strong>Notes:</strong> ARDA operates as a core capability within Euclidean Studios for high-fidelity 3D content, interactive experiences, and complex technical delivery pipelines.</p>
   </section>
 
 
   <section>
-    <h2><a href="https://www.icrc.org/" target="_blank">International Committee of the Red Cross (ICRC)</a> — VR Designer and R&D Lead</h2>
-    <p><strong>role:</strong> previously part of the virtual reality unit in belgrade (unit now closed).</p>
-    <p><strong>focus:</strong> immersive simulation and decision-training systems for humanitarian operations.</p>
-    <p><strong>responsibilities:</strong> scenario and experience design; technical implementation; R&amp;D leadership; collaboration with domain experts; cross-team production coordination; innovation initiatives across the unit.</p>
+    <h2><a href="https://www.icrc.org/" target="_blank">International Committee of the Red Cross (ICRC)</a> - VR Designer and R&D Lead</h2>
+    <p><strong>Role:</strong> Previously part of the Virtual Reality unit in Belgrade (unit now closed).</p>
+    <p><strong>Focus:</strong> Immersive simulation and decision-training systems for humanitarian operations.</p>
+    <p><strong>Responsibilities:</strong> Scenario and experience design; technical implementation; R&amp;D leadership; collaboration with domain experts; cross-team production coordination; innovation initiatives across the unit.</p>
   </section>
 
   <section>
     <h2>Industry and Community</h2>
-    <p><strong><a href="https://sga.rs/" target="_blank">serbian games association (sga):</a></strong> board member (2023–2025); ongoing lectures, workshops, mentorship, and contribution to industry strategy initiatives.</p>
-    <h3>talks, panels, workshops (selection):</h3>
+    <p><strong><a href="https://sga.rs/" target="_blank">Serbian Games Association (SGA):</a></strong> Board Member (2023-2025); ongoing lectures, workshops, mentorship, and contribution to industry strategy initiatives.</p>
+    <h3>Talks, Panels, Workshops (Selection):</h3>
     <ul>
-      <li>sessions on narrative and game systems for indie production, team design, and world-building.</li>
-      <li>talks on VR and simulation as serious applications of game technology.</li>
-      <li>moderation and panel leadership on the <a href="https://sga.rs/" target="_blank">Serbian indie scene</a> and regional ecosystem development.</li>
+      <li>Sessions on narrative and game systems for indie production, team design, and world-building.</li>
+      <li>Talks on VR and simulation as serious applications of game technology.</li>
+      <li>Moderation and panel leadership on the <a href="https://sga.rs/" target="_blank">Serbian indie scene</a> and regional ecosystem development.</li>
     </ul>
   </section>
 
   <section>
     <h2>Background &amp; Capabilities</h2>
     <ul>
-      <li><strong>design &amp; production:</strong> narrative and systems design; quest/dialogue architecture; cinematic supervision; milestone and scope governance.</li>
-      <li><strong>engineering:</strong> Unreal Engine (C++/Blueprints); production tooling; scalable pipelines for small interdisciplinary teams; real-time performance strategy.</li>
-      <li><strong>art direction:</strong> visual direction and coherence; concept review; scene composition; trailer and in-engine cinematic direction.</li>
-      <li><strong>data/ai foundation:</strong> data science, data engineering, computer vision, and AI applied to simulation design, production architecture, and game development workflows.</li>
-      <li><strong>team-building &amp; collaboration:</strong> building interdisciplinary teams across art, engineering, and design; alignment across disciplines; mentorship; partner and community collaboration.</li>
+      <li><strong>Design &amp; Production:</strong> Narrative and systems design; quest/dialogue architecture; cinematic supervision; milestone and scope governance.</li>
+      <li><strong>Engineering:</strong> Unreal Engine (C++/Blueprints); production tooling; scalable pipelines for small interdisciplinary teams; real-time performance strategy.</li>
+      <li><strong>Art Direction:</strong> Visual direction and coherence; concept review; scene composition; trailer and in-engine cinematic direction.</li>
+      <li><strong>Data/AI Foundation:</strong> Data science, data engineering, computer vision, and AI applied to simulation design, production architecture, and game development workflows.</li>
+      <li><strong>Team-Building &amp; Collaboration:</strong> Building and scaling interdisciplinary teams across art, engineering, and design; leadership alignment across disciplines; mentorship; partner and community collaboration.</li>
     </ul>
   </section>
 
@@ -67,34 +67,34 @@
     <h2>Selected Appearances (representative)</h2>
     <ul>
       <li>
-        <a href="https://kotorart.me/en/program/playing-narratives-x-shift2games-vanja-knezevic.1102.html" target="_blank">Playing Narratives x Shift2Games – KotorArt Festival (Perast, 2024)</a> — lecturer on VR, simulation, and game development, presenting work across Euclidean Studios and historical ICRC VR projects. Session held at the Monastery of St. Antun, Boka Bay.
+        <a href="https://kotorart.me/en/program/playing-narratives-x-shift2games-vanja-knezevic.1102.html" target="_blank">Playing Narratives x Shift2Games - KotorArt Festival (Perast, 2024)</a> - Lecturer on VR, simulation, and game development, presenting work across Euclidean Studios and historical ICRC VR projects. Session held at the Monastery of St. Antun, Boka Bay.
       </li>
       <li>
-         <a href="https://www.youtube.com/watch?v=dri2YLFfQns" target="_blank">Unreal Day 2024 (Belgrade)</a> — speaker, presenting on using Unreal Engine for independent game production, simulation systems, and training applications.
+         <a href="https://www.youtube.com/watch?v=dri2YLFfQns" target="_blank">Unreal Day 2024 (Belgrade)</a> - Speaker, presenting on using Unreal Engine for independent game production, simulation systems, and training applications.
       </li>
       <li>
-        <a href="https://ftwconference.com/" target="_blank">For the Win! 2025 (Belgrade, May 29)</a> — fireside chat in Hall 6 (Main Program) alongside Tim Browne (Bright Gambit) at the 4th edition of Serbia’s “100% Game Dev Conference.”
+        <a href="https://ftwconference.com/" target="_blank">For the Win! 2025 (Belgrade, May 29)</a> - Fireside chat in Hall 6 (Main Program) alongside Tim Browne (Bright Gambit) at the 4th edition of Serbia’s “100% Game Dev Conference.”
       </li>
       <li>
-        <a href="https://ftwconference.com/" target="_blank">For the Win! 2024 (Belgrade)</a> — participant in the main program as part of the wider speaker roster of regional and international industry professionals.
+        <a href="https://ftwconference.com/" target="_blank">For the Win! 2024 (Belgrade)</a> - Participant in the main program as part of the wider speaker roster of regional and international industry professionals.
       </li>
       <li>
-        <a href="https://unrealday.com/" target="_blank">Unreal Day Belgrade 2023</a> — speaker on simulation design and indie production.
+        <a href="https://unrealday.com/" target="_blank">Unreal Day Belgrade 2023</a> - Speaker on simulation design and indie production.
       </li>
       <li>
-        <a href="https://ftwconference.com/" target="_blank">FTW Conference</a> — panelist and workshop facilitator on game development and team structure.
+        <a href="https://ftwconference.com/" target="_blank">FTW Conference</a> - Panelist and workshop facilitator on game development and team structure.
       </li>
       <li>
-        Gamejam Tirana — mentor and jury member for game design and prototyping.
+        Gamejam Tirana - Mentor and jury member for game design and prototyping.
       </li>
       <li>
-        <a href="https://wnhub.io/" target="_blank">WhiteNights Conference 2023</a> — panel moderator, leading discussion on game development trends and regional industry perspectives.
+        <a href="https://wnhub.io/" target="_blank">WhiteNights Conference 2023</a> - Panel Moderator, leading discussion on game development trends and regional industry perspectives.
       </li>
       <li>
-        teaching and mentoring in various capacities, including workshops, lectures, and one-on-one mentorship for aspiring game developers and interdisciplinary creatives. 
+        Teaching and mentoring in various capacities, including workshops, lectures, and one-on-one mentorship for aspiring game developers and interdisciplinary creatives.
       </li>
       <li>
-        regular guest lecturer for Playing Narratives (SGA).
+        Regular guest lecturer for Playing Narratives (SGA).
       </li>
     </ul>
   </section>


### PR DESCRIPTION
### Motivation
- Make the homepage showcase recent work by embedding the Vimeo showreel and present the site with clearer, leadership-oriented messaging. 
- Normalize punctuation and capitalization for consistency and cleaner presentation across pages.

### Description
- Embedded the Vimeo showreel (`https://vimeo.com/1177113461`) on the homepage using a responsive iframe wrapped in a `.video-embed` container and corresponding CSS in `style.css`.
- Rewrote homepage and `work.html` copy to emphasize leadership, strategy, team-building, roadmap ownership, and delivery while retaining technical details.
- Standardized capitalization for headings, labels, and sentence starts across `index.html`, `work.html`, `essays.html`, `gifts.html`, and `contact.html` and replaced em-dashes with regular hyphens in updated content.
- Updated files: `index.html`, `work.html`, `contact.html`, `essays.html`, `gifts.html`, and `style.css`.

### Testing
- Checked for remaining em-dash characters with `rg -n "—" *.html essays/*.html style.css` and confirmed there are none (success).
- Ran `git diff --check` to surface whitespace/diff issues and received no warnings (success).
- Reviewed generated diffs to confirm copy, title, and embed markup changes were applied consistently (manual automated diff inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51a168e448324bc6fbaa4920f02ae)