### PR TITLE
Refresh website content using latest career JSON data

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -19,9 +19,7 @@
   <p>For professional inquiries, collaborations, consulting, or speaking invitations, feel free to reach out.</p>
 
   <p><address style="font-style: normal;">Email: <a href="mailto:vanja@vanjaknezevic.com">vanja@vanjaknezevic.com</a></address></p>
-  <p><address style="font-style: normal;">Phone / WhatsApp: <a href="tel:+381641007006">+381 64 100 7006</a></address></p>
   <p><address style="font-style: normal;">LinkedIn: <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a></address></p>
-  <p><address style="font-style: normal;">Website: <a href="https://vanjaknezevic.com" target="_blank" rel="noopener noreferrer">vanjaknezevic.com</a></address></p>
   <p><address style="font-style: normal;">Location: Belgrade, Serbia (open to remote and relocation)</address></p>
 </div>
 

--- a/contact.html
+++ b/contact.html
@@ -16,12 +16,14 @@
 
 <div class="container narrow">
   <h1>Contact</h1>
-  <p>For professional inquiries, collaborations, or speaking invitations, please get in touch via the listed channels. I respond as time permits and prioritize work aligned with leadership, strategy, and interactive product delivery.</p>
-  <p><address style="font-style: normal;">Email: <a href="mailto:knezevanja@gmail.com">knezevanja@gmail.com</a></address></p>
-  <p><address style="font-style: normal;">X: <a href="https://x.com/umetnist" target="_blank">@umetnist</a></address></p>
-  <p><address style="font-style: normal;">Discord: <a href="https://discord.com/" target="_blank">kirabo</a></address></p>
+  <p>For professional inquiries, collaborations, consulting, or speaking invitations, feel free to reach out.</p>
+
+  <p><address style="font-style: normal;">Email: <a href="mailto:vanja@vanjaknezevic.com">vanja@vanjaknezevic.com</a></address></p>
+  <p><address style="font-style: normal;">Phone / WhatsApp: <a href="tel:+381641007006">+381 64 100 7006</a></address></p>
+  <p><address style="font-style: normal;">LinkedIn: <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a></address></p>
+  <p><address style="font-style: normal;">Website: <a href="https://vanjaknezevic.com" target="_blank" rel="noopener noreferrer">vanjaknezevic.com</a></address></p>
+  <p><address style="font-style: normal;">Location: Belgrade, Serbia (open to remote and relocation)</address></p>
 </div>
 
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -85,8 +85,7 @@
     <h2>Contact</h2>
     <p>
       <a href="mailto:vanja@vanjaknezevic.com">vanja@vanjaknezevic.com</a><br>
-      <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a><br>
-      <a href="https://vanjaknezevic.com" target="_blank" rel="noopener noreferrer">vanjaknezevic.com</a>
+      <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a>
     </p>
   </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
-  <title>Vanja Knežević - Technical Creative Director | Unreal Engine | XR Simulation</title>
+  <title>Vanja Knežević - Creative Technologist | Technical Director | AI & Simulation</title>
 </head>
 <body>
 
@@ -17,57 +17,48 @@
 <div class="container narrow">
   <header class="hero">
     <h1>Vanja Knežević</h1>
-    <p class="hero-role">Creative Technologist, Technical Director, and Team Lead for Real-Time Interactive Systems</p>
-    <p><strong>I lead strategy, team formation, and end-to-end delivery for simulation, experience design, and AI-enabled interactive products.</strong></p>
-    <p>Experience spanning games, VR simulation, AI-native workflows, cross-functional leadership, and organizational development.</p>
-    <p>Former VR Designer & R&D Lead at ICRC<br>Co-Founder & Director at Euclidean Studios<br>Former Board Member at the Serbian Games Association</p>
+    <p class="hero-role">Creative Technologist · Technical Director · Managing Director (Interactive Media &amp; R&amp;D)</p>
+    <p><strong>I build teams, pipelines, and technical systems that turn complex ideas into shipped outcomes.</strong></p>
+    <p>My work spans games, VR simulation, AI systems, and interdisciplinary R&amp;D in both commercial and high-stakes operational contexts.</p>
+    <p>Co-Founder &amp; Managing Director at Euclidean Studios<br>Former Creative Technologist (VR Designer) at ICRC<br>Former Board Member at the Serbian Games Association</p>
   </header>
 
   <section>
-    <h2>Hire me / Availability</h2>
-    <p>Currently focused on:</p>
+    <h2>Current Focus</h2>
     <ul>
-      <li>Technical Director roles</li>
-      <li>Creative technology leadership</li>
-      <li>Simulation / XR systems</li>
-      <li>AI-enabled content pipelines</li>
+      <li>Technical direction for AI, simulation, and real-time interactive systems</li>
+      <li>0-to-1 product and R&amp;D delivery in ambiguous environments</li>
+      <li>Cross-functional team scaling across design, engineering, and production</li>
+      <li>Systems architecture for narrative-heavy games and interactive media</li>
     </ul>
-    <p>Available for senior consulting, leadership mandates, and long-term roles.</p>
+    <p>Open to senior leadership roles, consulting, and selected long-term collaborations (remote or relocation).</p>
     <p><a class="button-link" href="assets/vanja-knezevic-cv.pdf" download>Read my CV</a></p>
   </section>
 
   <section>
-    <h2>Projects</h2>
+    <h2>Selected Projects</h2>
     <article>
-      <h3>Nazralath: The Fallen World</h3>
-      <ul>
-        <li><strong>Role:</strong> Director / Technical Design</li>
-        <li><strong>Engine:</strong> Unreal Engine 5</li>
-        <li><strong>Type:</strong> Narrative RPG</li>
-        <li><strong>Focus:</strong> Systems-driven narrative RPG with branching world-state architecture</li>
-        <li><strong>Status:</strong> In late stages of production</li>
-      </ul>
+      <h3>Nazralath: The Fallen World (Euclidean Studios)</h3>
+      <p>Narrative CRPG where I serve as technical director and systems architect for progression tracking, dialogue hubs, conditional access logic, and persistent world state. Project traction includes ~65,000 wishlists and ~2,200 community members.</p>
     </article>
     <article>
-      <h3>VR Humanitarian Simulations</h3>
-      <ul>
-        <li><strong>Role:</strong> VR Designer and R&D Lead</li>
-        <li><strong>Org:</strong> International Committee of the Red Cross</li>
-        <li><strong>Type:</strong> Training simulations</li>
-        <li><strong>Focus:</strong> Decision-focused simulation design with measurable real-world training impact</li>
-      </ul>
+      <h3>Frontline Negotiations - AI Training Simulation (ICRC)</h3>
+      <p>Production-ready AI-driven negotiation simulation for humanitarian training contexts, combining real-time interaction, narrative structure, and stakeholder-facing usability.</p>
+    </article>
+    <article>
+      <h3>ARDA (Euclidean Studios)</h3>
+      <p>Commercial-facing R&amp;D and service division focused on VR, 3D, and interactive media, created to turn experimental studio capabilities into client-ready delivery.</p>
     </article>
   </section>
 
   <section>
-    <h2>Systems Thinking</h2>
-    <p>Core areas:</p>
+    <h2>Core Capabilities</h2>
     <ul>
-      <li>Interdisciplinary systems leadership</li>
-      <li>Real-time simulation systems</li>
-      <li>Narrative and gameplay systems architecture</li>
-      <li>AI-native creative and production pipelines</li>
-      <li>Technical storytelling and art direction</li>
+      <li>Technical Direction &amp; Game Systems Architecture</li>
+      <li>VR &amp; Simulation Design (Unreal Engine 5, Blueprints/C++)</li>
+      <li>AI Workflow Design, LLM Systems, and Internal Tooling</li>
+      <li>Pipeline Design &amp; Cross-Functional Production Alignment</li>
+      <li>R&amp;D Prototyping and Technical Storytelling</li>
     </ul>
   </section>
 
@@ -86,20 +77,16 @@
 
   <section>
     <h2>Talks &amp; Writing</h2>
-    <p>Selected talks and writing on leadership, production systems, and industry development:</p>
-    <ul>
-      <li>Building bridges between game development and adjacent sectors</li>
-      <li>Panels, lectures, and workshops through the Serbian Games Association</li>
-      <li>Leading and scaling interdisciplinary teams</li>
-    </ul>
-    <p>Explore <a href="essays.html">Essays</a> and additional <a href="work.html">Talks and Work History</a>.</p>
+    <p>I regularly speak about technical leadership, simulation design, and industry development through conferences, workshops, and Serbian Games Association initiatives.</p>
+    <p>Explore <a href="essays.html">Essays</a> and a broader list of <a href="work.html">roles, projects, and achievements</a>.</p>
   </section>
 
   <section>
     <h2>Contact</h2>
     <p>
-      <a href="mailto:vanja@euclideanstudios.com">vanja@euclideanstudios.com</a><br>
-      <a href="https://linkedin.com/in/vanjaknezevic" target="_blank" rel="noopener noreferrer">linkedin.com/in/vanjaknezevic</a>
+      <a href="mailto:vanja@vanjaknezevic.com">vanja@vanjaknezevic.com</a><br>
+      <a href="https://www.linkedin.com/in/knezevic-vanja/" target="_blank" rel="noopener noreferrer">linkedin.com/in/knezevic-vanja</a><br>
+      <a href="https://vanjaknezevic.com" target="_blank" rel="noopener noreferrer">vanjaknezevic.com</a>
     </p>
   </section>
 </div>

--- a/work.html
+++ b/work.html
@@ -16,90 +16,91 @@
 
 <div class="container narrow">
   <h1>Work</h1>
+  <p>This page captures selected leadership roles, projects, and outcomes across games, AI systems, simulation, and interactive media.</p>
 
   <section>
-    <h2><a href="https://euclideanstudios.com/" target="_blank">Euclidean Studios</a> - <a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank">Nazralath: The Fallen World</a></h2>
-    <p><strong>Role:</strong> Co-Founder; Technical Director; Producer.</p>
-    <p><strong>Focus:</strong> A systems-driven dark fantasy RPG with strong narrative structure and world-state reactivity.</p>
-    <p><strong>Responsibilities:</strong> Technical direction; systems architecture for narrative, quest, and dialogue; cross-discipline leadership; hiring and team development; roadmap ownership; production governance.</p>
-    <p><strong>Notes:</strong> Announcement trailer released; currently directing vertical-slice execution and production planning, including publishing strategy, budgeting, and milestone governance.</p>
-  </section>
+    <h2>Roles</h2>
 
-  <section>
-    <h2><a href="https://arda.euclideanstudios.com/" target="_blank">ARDA</a> - Animated Media &amp; Interactive Production</h2>
-    <p><strong>Role:</strong> Founder; Lead Developer &amp; Technical Director.</p>
-    <p><strong>Focus:</strong> R&D-led interactive production spanning concept, previs, animation, simulation, and final delivery.</p>
-    <p><strong>Responsibilities:</strong> Technical direction; R&amp;D leadership; production strategy; Unreal Engine architecture; cross-discipline systems design; and pipeline design that aligns art, engineering, and narrative teams.</p>
-    <p><strong>Notes:</strong> ARDA operates as a core capability within Euclidean Studios for high-fidelity 3D content, interactive experiences, and complex technical delivery pipelines.</p>
-  </section>
-
-
-  <section>
-    <h2><a href="https://www.icrc.org/" target="_blank">International Committee of the Red Cross (ICRC)</a> - VR Designer and R&D Lead</h2>
-    <p><strong>Role:</strong> Previously part of the Virtual Reality unit in Belgrade (unit now closed).</p>
-    <p><strong>Focus:</strong> Immersive simulation and decision-training systems for humanitarian operations.</p>
-    <p><strong>Responsibilities:</strong> Scenario and experience design; technical implementation; R&amp;D leadership; collaboration with domain experts; cross-team production coordination; innovation initiatives across the unit.</p>
-  </section>
-
-  <section>
-    <h2>Industry and Community</h2>
-    <p><strong><a href="https://sga.rs/" target="_blank">Serbian Games Association (SGA):</a></strong> Board Member (2023-2025); ongoing lectures, workshops, mentorship, and contribution to industry strategy initiatives.</p>
-    <h3>Talks, Panels, Workshops (Selection):</h3>
+    <h3>Co-Founder &amp; Managing Director - <a href="https://euclideanstudios.com" target="_blank" rel="noopener noreferrer">Euclidean Studios</a> (2018-present)</h3>
+    <p>Lead technical direction, systems architecture, and delivery across game development, R&amp;D, and client-facing interactive production.</p>
     <ul>
-      <li>Sessions on narrative and game systems for indie production, team design, and world-building.</li>
-      <li>Talks on VR and simulation as serious applications of game technology.</li>
-      <li>Moderation and panel leadership on the <a href="https://sga.rs/" target="_blank">Serbian indie scene</a> and regional ecosystem development.</li>
+      <li>Built and scaled interdisciplinary teams across design, code, 3D, and narrative.</li>
+      <li>Co-led development of <a href="https://store.steampowered.com/app/1968940/Nazralath_The_Fallen_World/" target="_blank" rel="noopener noreferrer">Nazralath: The Fallen World</a>, including global game-state and progression architecture.</li>
+      <li>Secured, executed, and reported on EUR 120,000 in innovation funding.</li>
+      <li>Established <a href="https://arda.euclideanstudios.com" target="_blank" rel="noopener noreferrer">ARDA</a> as a commercial-facing R&amp;D and service unit.</li>
+    </ul>
+
+    <h3>Creative Technologist (VR Designer) - <a href="https://www.icrc.org" target="_blank" rel="noopener noreferrer">International Committee of the Red Cross (ICRC)</a> (2021-11 to 2025-10)</h3>
+    <p>Worked in the ICRC VR Unit across simulation design, AI-enabled experience development, and emerging technology strategy.</p>
+    <ul>
+      <li>Designed VR and non-VR simulation systems for high-stakes humanitarian and operational training.</li>
+      <li>Built production-ready AI-driven simulation experiences with real-time interaction and narrative structure.</li>
+      <li>Designed and deployed generative-AI workflows in ComfyUI using reproducible pipelines.</li>
+      <li>Helped scale the VR Unit from 4 to 8 team members through end-to-end hiring and onboarding.</li>
+    </ul>
+
+    <h3>Board Member - <a href="https://sga.rs" target="_blank" rel="noopener noreferrer">Serbian Games Association</a> (2023-05 to 2025-05)</h3>
+    <p>Contributed to industry strategy, ecosystem programs, and international partnerships, including work connected to the Serbian games industry 2030 strategy.</p>
+
+    <h3>Executive Producer - Lost Legion Studios (2020-2021)</h3>
+    <p>Production and pipeline coordination for animation projects including <em>Angels of Death</em> and <em>The Exodite</em>, with a focus on agile workflow integration.</p>
+  </section>
+
+  <section>
+    <h2>Selected Projects</h2>
+
+    <h3>Nazralath: The Fallen World - Narrative CRPG</h3>
+    <p><strong>Role:</strong> Technical Director and core systems architect.</p>
+    <p><strong>Focus:</strong> Progression systems, dialogue hubs, persistent world state, and conditional access architecture integrated across design, engineering, and art pipelines.</p>
+    <p><strong>Impact:</strong> ~65,000 wishlists and ~2,200 community members.</p>
+
+    <h3>Frontline Negotiations - AI Training Simulation (ICRC)</h3>
+    <p><strong>Role:</strong> Experience and systems lead for AI-driven negotiation simulation.</p>
+    <p><strong>Focus:</strong> Real-time AI interaction, narrative logic, and stakeholder-facing usability in humanitarian training contexts.</p>
+    <p><strong>Link:</strong> <a href="https://frontline-negotiations.org/artificial-intelligence/" target="_blank" rel="noopener noreferrer">frontline-negotiations.org/artificial-intelligence</a></p>
+
+    <h3>ARDA - Euclidean Studios</h3>
+    <p>Commercial-facing R&amp;D and service division for VR, 3D, and interactive media delivery.</p>
+
+    <h3>Medici - AI Retail / Spatial Systems Startup</h3>
+    <p>Founded and led an AI retail startup, building recommendation systems, search infrastructure, and ETL/normalization pipelines across fragmented retail data feeds.</p>
+
+    <h3>Internal Tooling</h3>
+    <ul>
+      <li><strong>Concierge:</strong> CV tailoring system for role-specific resume generation (<a href="https://github.com/kirabot/concierge" target="_blank" rel="noopener noreferrer">GitHub</a>).</li>
+      <li><strong>Euclidean Invoice:</strong> internal invoice generator for faster, more reliable studio administration (<a href="https://github.com/kirabot/euclidean-invoice" target="_blank" rel="noopener noreferrer">GitHub</a>).</li>
+    </ul>
+
+    <h3>Additional Creative/Research Work</h3>
+    <ul>
+      <li><a href="https://novolicecelekule.com/" target="_blank" rel="noopener noreferrer">Novo lice Cele-kule</a> (digital heritage facial reconstruction contribution).</li>
+      <li><a href="https://euclideanstudios.itch.io/emperor-citizen-slave" target="_blank" rel="noopener noreferrer">Emperor, Citizen, Slave</a> (small published game prototype).</li>
+      <li>Concept and design documentation projects, including <em>Pilgrims</em> and <em>ALIGNMENT</em>.</li>
     </ul>
   </section>
 
   <section>
-    <h2>Background &amp; Capabilities</h2>
+    <h2>Selected Achievements</h2>
     <ul>
-      <li><strong>Design &amp; Production:</strong> Narrative and systems design; quest/dialogue architecture; cinematic supervision; milestone and scope governance.</li>
-      <li><strong>Engineering:</strong> Unreal Engine (C++/Blueprints); production tooling; scalable pipelines for small interdisciplinary teams; real-time performance strategy.</li>
-      <li><strong>Art Direction:</strong> Visual direction and coherence; concept review; scene composition; trailer and in-engine cinematic direction.</li>
-      <li><strong>Data/AI Foundation:</strong> Data science, data engineering, computer vision, and AI applied to simulation design, production architecture, and game development workflows.</li>
-      <li><strong>Team-Building &amp; Collaboration:</strong> Building and scaling interdisciplinary teams across art, engineering, and design; leadership alignment across disciplines; mentorship; partner and community collaboration.</li>
+      <li>Secured EUR 120,000 in non-dilutive funding and delivered full-cycle grant execution.</li>
+      <li>Built production-ready AI-driven simulation systems for real-time narrative interaction.</li>
+      <li>Unified pipelines across design, code, art, and narrative in cross-functional teams.</li>
+      <li>Contributed to organizational AI strategy in training, logistics, communication, and crisis-response contexts.</li>
+      <li>Built an LLM-powered organizational knowledge system with cross-source retrieval and report generation.</li>
+      <li>Introduced agile workflows in 3D animation production environments.</li>
     </ul>
   </section>
 
   <section>
-    <h2>Selected Appearances (representative)</h2>
+    <h2>Talks &amp; Industry Participation (Selection)</h2>
     <ul>
-      <li>
-        <a href="https://kotorart.me/en/program/playing-narratives-x-shift2games-vanja-knezevic.1102.html" target="_blank">Playing Narratives x Shift2Games - KotorArt Festival (Perast, 2024)</a> - Lecturer on VR, simulation, and game development, presenting work across Euclidean Studios and historical ICRC VR projects. Session held at the Monastery of St. Antun, Boka Bay.
-      </li>
-      <li>
-         <a href="https://www.youtube.com/watch?v=dri2YLFfQns" target="_blank">Unreal Day 2024 (Belgrade)</a> - Speaker, presenting on using Unreal Engine for independent game production, simulation systems, and training applications.
-      </li>
-      <li>
-        <a href="https://ftwconference.com/" target="_blank">For the Win! 2025 (Belgrade, May 29)</a> - Fireside chat in Hall 6 (Main Program) alongside Tim Browne (Bright Gambit) at the 4th edition of Serbia’s “100% Game Dev Conference.”
-      </li>
-      <li>
-        <a href="https://ftwconference.com/" target="_blank">For the Win! 2024 (Belgrade)</a> - Participant in the main program as part of the wider speaker roster of regional and international industry professionals.
-      </li>
-      <li>
-        <a href="https://unrealday.com/" target="_blank">Unreal Day Belgrade 2023</a> - Speaker on simulation design and indie production.
-      </li>
-      <li>
-        <a href="https://ftwconference.com/" target="_blank">FTW Conference</a> - Panelist and workshop facilitator on game development and team structure.
-      </li>
-      <li>
-        Gamejam Tirana - Mentor and jury member for game design and prototyping.
-      </li>
-      <li>
-        <a href="https://wnhub.io/" target="_blank">WhiteNights Conference 2023</a> - Panel Moderator, leading discussion on game development trends and regional industry perspectives.
-      </li>
-      <li>
-        Teaching and mentoring in various capacities, including workshops, lectures, and one-on-one mentorship for aspiring game developers and interdisciplinary creatives.
-      </li>
-      <li>
-        Regular guest lecturer for Playing Narratives (SGA).
-      </li>
+      <li><a href="https://www.youtube.com/watch?v=dri2YLFfQns" target="_blank" rel="noopener noreferrer">Unreal Day 2024 (Belgrade)</a> - speaker on Unreal Engine for game production and simulation systems.</li>
+      <li><a href="https://kotorart.me/en/program/playing-narratives-x-shift2games-vanja-knezevic.1102.html" target="_blank" rel="noopener noreferrer">Playing Narratives x Shift2Games - KotorArt 2024</a> - lecturer on VR, simulation, and game development.</li>
+      <li><a href="https://ftwconference.com/" target="_blank" rel="noopener noreferrer">FTW Conference</a> - main-program participation, panels, and workshops.</li>
+      <li><a href="https://wnhub.io/" target="_blank" rel="noopener noreferrer">White Nights 2023</a> - panel moderation and regional industry discussion.</li>
     </ul>
   </section>
 </div>
 
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- Update the public site to reflect the most recent structured career/profile JSON, bringing roles, projects, achievements, and contact details in line with the latest data.
- Make work and projects easier to discover by reorganizing content into clearer sections (roles, selected projects, achievements, talks). 
- Replace outdated contact and hero copy with current professional email, phone, LinkedIn, website, and availability details.

### Description
- Updated `index.html` to refresh the hero/title, repositioning copy, update the page title, and replace the previous “Hire me” block with a `Current Focus` list and a `Selected Projects` summary. 
- Reworked `work.html` to explicitly separate `Roles`, `Selected Projects`, `Selected Achievements`, and `Talks & Industry Participation`, and added items such as `Nazralath`, `Frontline Negotiations`, `ARDA`, `Medici`, and internal tooling (`Concierge`, `Euclidean Invoice`).
- Replaced legacy contact details in `contact.html` with the current professional `Email`, `Phone / WhatsApp`, `LinkedIn`, `Website`, and `Location` fields, and ensured `mailto:`/`tel:` links and external link attributes (`rel="noopener noreferrer"`) are present.
- Kept the existing layout and styling, preserved the showreel embed, and updated internal links to point at authoritative project and profile URLs where available.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues, which completed successfully. 
- Ran `git status --short` to confirm the intended files were modified (`index.html`, `work.html`, `contact.html`) and the working tree state, which completed successfully. 
- Performed a manual review of the updated HTML files for structure and link consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64d019b4c8324af766cf8e7c3f831)